### PR TITLE
Update main.css

### DIFF
--- a/vue/src/assets/styles/main.css
+++ b/vue/src/assets/styles/main.css
@@ -9,6 +9,7 @@
 html {
     -webkit-text-size-adjust: none;
     touch-action: manipulation;
+    overflow-y: hidden;
 }
 
 body {


### PR DESCRIPTION
Hide unnecessary vertical overflow scrollbars from appearing, which looks to be more of an issue on Webkit.

![Screenshot from 2021-01-21 23-24-40](https://user-images.githubusercontent.com/31819/105419978-dd465080-5c3f-11eb-8002-2acf26da7537.png)
