### PR TITLE
Refactor: Don't show example snapshots header without examples

### DIFF
--- a/vue/src/views/Snapshot.vue
+++ b/vue/src/views/Snapshot.vue
@@ -95,14 +95,11 @@
           :snapshots="snapshotsStore" :withTopic="true"
         />
 
-        <v-subheader
-          class="px-0 snapshot-list-title">{{ listtitleText }}
-        </v-subheader>
+        <template v-if="snapshotsExamples.length !== 0">
+          <v-subheader class="px-0 snapshot-list-title">{{ listtitleText }}</v-subheader>
 
-        <snapshot-list
-          v-if="snapshotsExamples"
-          :snapshots="snapshotsExamples" :withTopic="false"
-        />
+          <snapshot-list :snapshots="snapshotsExamples" :withTopic="false" />
+        </template>
 
       </div>
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make test` passes (is also automatically run by Github Actions)
- [ ] documentation is changed or added

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected components
<!-- Please provide affected core subsystem(s). -->
* `vue/src/views/Snapshot.vue`

### Description of change
<!-- Please provide a description of the change here. -->
* Example snapshots and its header (*Weitere Fallbeispiele*) are now only shown if there are examples
