### PR TITLE
Refactor: Don't show selected locale when switching

### DIFF
--- a/vue/src/components/LanguageSwitch.vue
+++ b/vue/src/components/LanguageSwitch.vue
@@ -1,7 +1,7 @@
 <template>
 <div v-if="expanded">
     <v-btn
-      v-for="lang in languages"
+      v-for="lang in $i18n.availableLocales"
       :key="lang"
       fab
       small
@@ -25,7 +25,7 @@
       </v-btn>
     </template>
     <v-btn
-      v-for="lang in languages"
+      v-for="lang in $i18n.availableLocales.filter(language => language !== $i18n.locale)"
       :key="lang"
       fab
       small
@@ -40,13 +40,7 @@
 <script>
 export default {
   name: 'LanguageSwitch',
-  data() {
-    return {
-      languages: ['de', 'fr']
-    };
-  },
   props: ['expanded'],
-
   methods: {
     changeLanguage(lang) {
       this.$i18n.locale = lang;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make test` passes (is also automatically run by Github Actions)
- [ ] documentation is changed or added

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected components
<!-- Please provide affected core subsystem(s). -->
* `vue/src/components/LanguageSwitch.vue`

### Description of change
<!-- Please provide a description of the change here. -->
* `$i18n.availableLocales` are now used as languages
* The current language is no longer shown as a locale that can be switched to
