### PR TITLE
Fix: Map controls overlapping nav

### DIFF
--- a/vue/src/assets/styles/main.css
+++ b/vue/src/assets/styles/main.css
@@ -80,7 +80,7 @@ a {
 
 #snapshotnav {
   height: calc(100vh - var(--vh-offset, 0px)) !important;
-  z-index: 100; /* must be above mapbox interface */
+  z-index: 1001; /* must be above leaflet interface */
 }
 
 #snapshotnavContent {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make test` passes (is also automatically run by Github Actions)
- [ ] documentation is changed or added

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected components
<!-- Please provide affected core subsystem(s). -->
* `vue/src/assets/styles/main.css`

### Description of change
<!-- Please provide a description of the change here. -->
* `z-index` of `#snapshotnav` is now `1001` (map controls are `1000`)
