### PR TITLE
Fix: Safari v-file-input

### DIFF
--- a/vue/src/assets/styles/main.css
+++ b/vue/src/assets/styles/main.css
@@ -98,3 +98,8 @@ a {
 }
 
 /* SNAPSHOTS END */
+
+/* fixes input overlapping appended elements on safari */
+.v-file-input input {
+  overflow: hidden;
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

<!-- _Please make sure to review and check all of these items:_ -->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make tests` passes (is also automatically run by Github Actions)
- [x] documentation is changed or added

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected components

<!-- Please provide affected core subsystem(s). -->

* `vue/src/assets/styles/main.css`

### Description of change

<!-- Please provide a description of the change here. -->

* `<input>` elements within `v-file-input` components now hide their overflow
