### PR TITLE
Fix: Workspace modal z-index

### DIFF
--- a/vue/src/views/Workspace.vue
+++ b/vue/src/views/Workspace.vue
@@ -67,7 +67,7 @@
     <v-overlay
       absolute="absolute"
       opacity="0.2"
-      z-index="1000"
+      z-index="1002"
       :value="!!editing"
       >
       <snapshot-edit


### PR DESCRIPTION
is now above snapshot nav

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

<!-- _Please make sure to review and check all of these items:_ -->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make tests` passes (is also automatically run by Github Actions)
- [x] documentation is changed or added

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected components

<!-- Please provide affected core subsystem(s). -->
* `vue/src/views/Workspace.vue`

### Description of change

<!-- Please provide a description of the change here. -->
* Snapshot edit modal now has higher z-index than snapshot nav

See #13 