### PR TITLE
Added git tag & commit version to footers of frontend and backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ DOCKER_EXEC_VUE=$(shell command -v docker > /dev/null && echo "docker-compose ex
 DOCKER_EXEC_WWW=$(shell command -v docker > /dev/null && echo "docker-compose exec $(NOTTY) www")
 
 
-.PHONY: tests
+.PHONY: deploy_version
 
 init:
 	cd django && make init
@@ -87,3 +87,9 @@ import-db:
 tests:
 	cd django && make tests
 	cd vue && make tests
+
+deploy_version:
+	bash -c 'printf "%s\t%s" "$$(git describe --abbrev=0 --tags)" "$$(git rev-parse --short HEAD)" > django/VERSION'
+	cp django/VERSION vue/VERSION
+
+-include deploy_version

--- a/django/.gitignore
+++ b/django/.gitignore
@@ -1,1 +1,2 @@
 tmp
+VERSION

--- a/django/main/settings.py
+++ b/django/main/settings.py
@@ -1,4 +1,5 @@
 import os
+import os.path
 
 # use your own secret_key, default for testing and dev
 SECRET_KEY = os.getenv('DJANGO_SECRET_KEY') or os.getenv('DJANGO_SECRET_KEY_DEV')
@@ -19,6 +20,18 @@ MANAGERS = ADMINS
 ADMIN_NAME = os.environ.get('DJANGO_ADMIN_NAME', 'gemeindescan DEV')
 ADMIN_HEADER_COLOR = os.environ.get('DJANGO_ADMIN_HEADER_COLOR', '#543076')
 LOGIN_PAGE_TITLE = os.environ.get('LOGIN_PAGE_TITLE', 'Gemeindescan')
+
+CURRENT_TAG_VERSION = "NaN.NaN.NaN"
+CURRENT_COMMIT_VERSION = "NaN"
+
+if os.path.isfile("VERSION"):
+    with open("VERSION", 'r') as f:
+        try:
+            content = f.read().split("\t")
+            CURRENT_TAG_VERSION = content[0]
+            CURRENT_COMMIT_VERSION = content[1]
+        except:
+            pass
 
 if os.environ.get('DJANGO_ALLOWED_HOSTS'):
     ALLOWED_HOSTS = os.environ.get('DJANGO_ALLOWED_HOSTS', '').split(',')

--- a/django/main/templates/admin/base.html
+++ b/django/main/templates/admin/base.html
@@ -101,10 +101,10 @@
     </div>
 </div>
 <!-- END Container -->
-</body>
 <footer>
-    <a target="_blank" href="https://github.com/cividi/spatial-data-package-platform/releases/tag/{{CURRENT_TAG_VERSION}}">v{{CURRENT_TAG_VERSION}}</a>
-    &nbsp;
-    (<a target="_blank" href="https://github.com/cividi/spatial-data-package-platform/commit/{{CURRENT_COMMIT_VERSION}}">{{CURRENT_COMMIT_VERSION}}</a>)
+  <a target="_blank" href="https://github.com/cividi/spatial-data-package-platform/releases/tag/{{CURRENT_TAG_VERSION}}">v{{CURRENT_TAG_VERSION}}</a>
+  &nbsp; 
+  (<a target="_blank" href="https://github.com/cividi/spatial-data-package-platform/commit/{{CURRENT_COMMIT_VERSION}}">{{CURRENT_COMMIT_VERSION}}</a>)
 </footer>
+</body>
 </html>

--- a/django/main/templates/admin/base.html
+++ b/django/main/templates/admin/base.html
@@ -1,0 +1,110 @@
+{% load i18n static %}<!DOCTYPE html>
+{% get_current_language as LANGUAGE_CODE %}{% get_current_language_bidi as LANGUAGE_BIDI %}
+<html lang="{{ LANGUAGE_CODE|default:"en-us" }}" dir="{{ LANGUAGE_BIDI|yesno:'rtl,ltr,auto' }}">
+<head>
+<title>{% block title %}{% endblock %}</title>
+<link rel="stylesheet" type="text/css" href="{% block stylesheet %}{% static "admin/css/base.css" %}{% endblock %}">
+{% if not is_popup and is_nav_sidebar_enabled %}
+  <link rel="stylesheet" type="text/css" href="{% static "admin/css/nav_sidebar.css" %}">
+  <script src="{% static 'admin/js/nav_sidebar.js' %}" defer></script>
+{% endif %}
+{% block extrastyle %}{% endblock %}
+{% if LANGUAGE_BIDI %}<link rel="stylesheet" type="text/css" href="{% block stylesheet_rtl %}{% static "admin/css/rtl.css" %}{% endblock %}">{% endif %}
+{% block extrahead %}{% endblock %}
+{% block responsive %}
+    <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <link rel="stylesheet" type="text/css" href="{% static "admin/css/responsive.css" %}">
+    {% if LANGUAGE_BIDI %}<link rel="stylesheet" type="text/css" href="{% static "admin/css/responsive_rtl.css" %}">{% endif %}
+{% endblock %}
+{% block blockbots %}<meta name="robots" content="NONE,NOARCHIVE">{% endblock %}
+</head>
+
+<body class="{% if is_popup %}popup {% endif %}{% block bodyclass %}{% endblock %}"
+  data-admin-utc-offset="{% now "Z" %}">
+
+<!-- Container -->
+<div id="container">
+
+    {% if not is_popup %}
+    <!-- Header -->
+    {% block header %}
+    <div id="header">
+        <div id="branding">
+        {% block branding %}{% endblock %}
+        </div>
+        {% block usertools %}
+        {% if has_permission %}
+        <div id="user-tools">
+            {% block welcome-msg %}
+                {% translate 'Welcome,' %}
+                <strong>{% firstof user.get_short_name user.get_username %}</strong>.
+            {% endblock %}
+            {% block userlinks %}
+                {% if site_url %}
+                    <a href="{{ site_url }}">{% translate 'View site' %}</a> /
+                {% endif %}
+                {% if user.is_active and user.is_staff %}
+                    {% url 'django-admindocs-docroot' as docsroot %}
+                    {% if docsroot %}
+                        <a href="{{ docsroot }}">{% translate 'Documentation' %}</a> /
+                    {% endif %}
+                {% endif %}
+                {% if user.has_usable_password %}
+                <a href="{% url 'admin:password_change' %}">{% translate 'Change password' %}</a> /
+                {% endif %}
+                <a href="{% url 'admin:logout' %}">{% translate 'Log out' %}</a>
+            {% endblock %}
+        </div>
+        {% endif %}
+        {% endblock %}
+        {% block nav-global %}{% endblock %}
+    </div>
+    {% endblock %}
+    <!-- END Header -->
+    {% block breadcrumbs %}
+    <div class="breadcrumbs">
+    <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+    {% if title %} &rsaquo; {{ title }}{% endif %}
+    </div>
+    {% endblock %}
+    {% endif %}
+
+    <div class="main" id="main">
+      {% if not is_popup and is_nav_sidebar_enabled %}
+        {% block nav-sidebar %}
+          {% include "admin/nav_sidebar.html" %}
+        {% endblock %}
+      {% endif %}
+      <div class="content">
+        {% block messages %}
+          {% if messages %}
+            <ul class="messagelist">{% for message in messages %}
+              <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message|capfirst }}</li>
+            {% endfor %}</ul>
+          {% endif %}
+        {% endblock messages %}
+        <!-- Content -->
+        <div id="content" class="{% block coltype %}colM{% endblock %}">
+          {% block pretitle %}{% endblock %}
+          {% block content_title %}{% if title %}<h1>{{ title }}</h1>{% endif %}{% endblock %}
+          {% block content_subtitle %}{% if subtitle %}<h2>{{ subtitle }}</h2>{% endif %}{% endblock %}
+          {% block content %}
+            {% block object-tools %}{% endblock %}
+            {{ content }}
+          {% endblock %}
+          {% block sidebar %}{% endblock %}
+          <br class="clear">
+        </div>
+        <!-- END Content -->
+        {% block footer %}<div id="footer"></div>{% endblock %}
+      </div>
+    </div>
+</div>
+<!-- END Container -->
+</body>
+<footer>
+    <a target="_blank" href="https://github.com/cividi/spatial-data-package-platform/releases/tag/{{CURRENT_TAG_VERSION}}">v{{CURRENT_TAG_VERSION}}</a>
+    &nbsp;
+    (<a target="_blank" href="https://github.com/cividi/spatial-data-package-platform/commit/{{CURRENT_COMMIT_VERSION}}">{{CURRENT_COMMIT_VERSION}}</a>)
+</footer>
+</html>

--- a/django/main/templates/admin/base_site.html
+++ b/django/main/templates/admin/base_site.html
@@ -77,10 +77,20 @@
         text-align: center;
         color: white;
         font-weight: bold;
-        background-color: #ff0000;
+        background-color: {{ ADMIN_HEADER_COLOR }};
         display: flex;
         justify-content: center;
         align-items: center;
+        font-weight: 300;
+    }
+    footer a,
+    footer a:focus,
+    footer a:link,
+    footer a:visited {
+        color: white;
+    }
+    footer a:hover{
+        font-weight: 900;
     }
 </style>
 {% endblock %}

--- a/django/main/templates/admin/base_site.html
+++ b/django/main/templates/admin/base_site.html
@@ -64,5 +64,23 @@
     .object-tools a:focus, .object-tools a:hover {
         background-color: #543076;
     }
+    body {
+        height: auto;
+        min-height: calc(100vh - 35px);
+    }
+    body #container {
+        height: auto;
+        min-height: calc(100vh - 35px);
+    }
+    footer {
+        height: 35px;
+        text-align: center;
+        color: white;
+        font-weight: bold;
+        background-color: #ff0000;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+    }
 </style>
 {% endblock %}

--- a/django/main/utils.py
+++ b/django/main/utils.py
@@ -19,4 +19,6 @@ def context_processor(request):
     return {
         'ADMIN_HEADER_COLOR': settings.ADMIN_HEADER_COLOR,
         'LOGIN_PAGE_TITLE': settings.LOGIN_PAGE_TITLE,
+        'CURRENT_TAG_VERSION': settings.CURRENT_TAG_VERSION,
+        'CURRENT_COMMIT_VERSION': settings.CURRENT_COMMIT_VERSION
     }

--- a/vue/.gitignore
+++ b/vue/.gitignore
@@ -19,3 +19,5 @@ yarn-error.log*
 *.njsproj
 *.sln
 *.sw?
+
+VERSION

--- a/vue/src/components/Version.vue
+++ b/vue/src/components/Version.vue
@@ -1,0 +1,25 @@
+<template>
+  <div class="version">
+    <a target="_blank" :href="'https://github.com/cividi/spatial-data-package-platform/releases/tag/' + version[0]">v{{version[0]}}</a>
+    &nbsp;
+    (<a target="_blank" :href="'https://github.com/cividi/spatial-data-package-platform/commit/' + version[1]">{{version[1]}}</a>)
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'Version',
+  data() {
+    return {
+      version: process.env.VUE_APP_GIT_VERSION.split('\t')
+    };
+  }
+};
+</script>
+
+<style>
+  .version {
+    height: 35px;
+    text-align: center;
+  }
+</style>

--- a/vue/src/layouts/LayoutDefault.vue
+++ b/vue/src/layouts/LayoutDefault.vue
@@ -7,6 +7,8 @@
           <slot/>
         </v-slide-y-transition>
       </v-content>
+
+      <version />
     </main>
 </template>
 

--- a/vue/src/main.js
+++ b/vue/src/main.js
@@ -15,6 +15,7 @@ import LanguageSwitch from './components/LanguageSwitch.vue';
 import UserActions from './components/UserActions.vue';
 import MainNavigation from './components/MainNavigation.vue';
 import Search from './components/Search.vue';
+import Version from './components/Version.vue';
 import App from './App.vue';
 import 'mapbox.js/dist/mapbox.css';
 
@@ -53,6 +54,7 @@ Vue.use(VueCookies);
 Vue.component('language-switch', LanguageSwitch);
 Vue.component('user-actions', UserActions);
 Vue.component('main-navigation', MainNavigation);
+Vue.component('version', Version);
 Vue.component('search', Search);
 
 new Vue({

--- a/vue/vue.config.js
+++ b/vue/vue.config.js
@@ -1,3 +1,16 @@
+const fs = require('fs');
+
+process.env.VUE_APP_GIT_VERSION = 'NaN.NaN.NaN\tNaN';
+
+try {
+  if (fs.existsSync('VERSION')) {
+    process.env.VUE_APP_GIT_VERSION = fs.readFileSync('VERSION', 'utf8');
+  }
+} catch(err) {
+  //pass
+}
+
+
 module.exports = {
   devServer: {
     compress: true,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

<!-- _Please make sure to review and check all of these items:_ -->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make tests` passes (is also automatically run by Github Actions)
- [ ] documentation is changed or added

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected components

<!-- Please provide affected core subsystem(s). -->
 Makefile
 django/main/settings.py
 django/main/templates/admin/base.html
 django/main/templates/admin/base_site.html
 django/main/utils.py
 vue/src/components/Version.vue
 vue/src/layouts/LayoutDefault.vue
 vue/src/main.js
 vue/vue.config.js

### Description of change

<!-- Please provide a description of the change here. -->
Added GIT Tag & Commit Version to footer of vue frontend and django admin backend. The footer has now two anchor links one for the respective tag on Github and the other one a link to the respective commit on github

The current git tag & commit they get deployed from the root Makefile script to the files `django/VERSION` and `vue/VERSION`, since the docker containers don't have access to the git tree. Then django and vue read the files, the versions are separated by tabulation and they getting read accordingly.

The Makefile script will deploy the version everytime any command gets executed. May be overhead, but this way we can ensure that we always have the current version deployed without thinking about it.

The VERSION files were added to the gitignore

On Vue the Version gets passed by a process.env variable on vue.config, in order to ensure that the version gets passed also on build mode and dev mode.