### PR TITLE
support custom fathom domain via env://FATHOM_URL, fixes #244

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,13 @@ DJANGO_SECRET=some.R4nd0m_k3y
 MAPBOX_TOKEN=a.mapbox.api.token
 MAPBOX_STYLE=mapbox://styles/gemeindescan/ck6rp249516tg1iqkmt48o4pz
 ```
-..which will be sourced by the Makefile scripts. Or use some other way to configure your environment.
+...which will be sourced by the Makefile scripts. Or use some other way to configure your environment.
+
+If you want to add support for Fathom analytics add these two optional environment variables as well:
+```bash
+FATHOM_SITEID=you.fathom.siteid
+FATHOM_URL=custom.domain.net # needs extra setup
+```
 
 (2) Download containers and start them
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -34,6 +34,7 @@ services:
       - VUE_APP_GRAPHQL_URI=http://www:8000/graphql/
       - VUE_APP_DJANGOBASEURL=http://www:8000
       - VUE_APP_FATHOM_SITEID=${FATHOM_SITEID}
+      - VUE_APP_FATHOM_URL=${FATHOM_URL}
       - VUE_APP_SNAPSHOTSTOREURL=https://gemeindescan.eu-central-1.linodeobjects.com/public/
       - PUBLIC_URL=http://www:8000
     working_dir: /opt/vue

--- a/vue/src/App.vue
+++ b/vue/src/App.vue
@@ -21,7 +21,8 @@ import LayoutDefault from '@/layouts/LayoutDefault.vue';
 export default {
   data() {
     return {
-      fathomSiteId: process.env.VUE_APP_FATHOM_SITEID
+      fathomSiteId: process.env.VUE_APP_FATHOM_SITEID,
+      fathomUrl: process.env.VUE_APP_FATHOM_URL || 'cdn.usefathom.com'
     };
   },
 
@@ -41,7 +42,7 @@ export default {
   mounted() {
     if (this.fathomSiteId !== '') {
       const fathomScript = document.createElement('script');
-      fathomScript.setAttribute('src', 'https://cdn.usefathom.com/script.js');
+      fathomScript.setAttribute('src', `https://${this.fathomUrl}/script.js`);
       fathomScript.setAttribute('spa', 'auto');
       fathomScript.setAttribute('data-site', this.fathomSiteId);
       fathomScript.setAttribute('exluded-domains', 'www,www.local,localhost');


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make tests` passes (is also automatically run by Github Actions)
- [x] documentation is changed or added

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected components

- App.vue
- docker-compose.dev.yml

### Description of change

Added support for fathom custom domains - see #244.