### PR TITLE
Deactivate like button

### DIFF
--- a/django/gsmap/models.py
+++ b/django/gsmap/models.py
@@ -439,18 +439,25 @@ def send_new_annotation_email(sender, instance, created, **kwargs):
 
       if created:
         recipient = instance.author_email
-        idstr = str(instance.id)
-
-        uniquestr = recipient + idstr + SECRET_KEY
-        publishKeyHex = hashlib.md5(uniquestr.encode()).hexdigest()
-        website = get_website(Site.objects.get_current())
-        publish_url = reverse('annotation-publish', args=[idstr, publishKeyHex])
-
         subject = 'Kommentar freischalten'
         message = 'Besten Dank für Ihren Kommentar!\n'
-        message += 'Sie Können ihn unter folgender URL freischalten:\n'
-        message += f'{website["base"]}{publish_url}\n'
-        message += '--' * 30
+
+        website = get_website(Site.objects.get_current())
+
+        if instance.workspace.annotations_open:
+            idstr = str(instance.id)
+
+            uniquestr = recipient + idstr + SECRET_KEY
+            publishKeyHex = hashlib.md5(uniquestr.encode()).hexdigest()
+            publish_url = reverse('annotation-publish', args=[idstr, publishKeyHex])
+
+            message += 'Sie können ihn unter folgender URL freischalten:\n'
+            message += f'{website["base"]}{publish_url}\n'
+            message += '--' * 30
+        else:
+            message += "Leider ist die Beteiligung nun abgeschlossen.\n"
+            message += f"Zur Karte mit allen öffentlichen Kommentaren: {website['base']}/de/{instance.workspace.pk}/{instance.workspace.snapshots.first().pk}/"
+            message += '--' * 30
 
         send_mail(
             subject,

--- a/django/gsmap/serializers.py
+++ b/django/gsmap/serializers.py
@@ -23,6 +23,13 @@ class AnnotationSerializer(serializers.ModelSerializer):
         )
 
 class AnnotationRateUpSerializer(serializers.ModelSerializer):
+    annotations_open = serializers.BooleanField()
+
     class Meta:
         model = Annotation
-        fields = ('rating',)
+        fields = ('rating', 'annotations_open')
+
+    def validate(self, data):
+        if not data.get("annotations_open"):
+            raise serializers.ValidationError(f'Rating annotations is not allowed currently for this workspace.')
+        return data

--- a/django/gsmap/views.py
+++ b/django/gsmap/views.py
@@ -86,7 +86,8 @@ class AnnotationRateUpView(generics.UpdateAPIView):
 
     def patch(self, request, *args, **kwargs):
         instance = self.get_object()
-        data = {"rating": instance.rating + 1}
+        workspace = Workspace.objects.filter(annotation=instance).first()
+        data = {"rating": instance.rating + 1, "annotations_open": workspace.annotations_open}
         serializer = self.get_serializer(instance, data=data, partial=True)
         serializer.is_valid(raise_exception=True)
         self.perform_update(serializer)

--- a/vue/src/components/SnapshotMap.vue
+++ b/vue/src/components/SnapshotMap.vue
@@ -87,14 +87,15 @@
         />
       </v-card>
 
+      <v-btn
+        fab absolute small
+        id="myLocation"
+        color="primary"
+        @click="myLocation">
+        <v-icon>mdi-crosshairs-gps</v-icon>
+      </v-btn>
+
       <div v-if="wshash && annotationsOpen && !screenshotMode">
-        <v-btn
-          fab absolute small
-          id="myLocation"
-          color="primary"
-          @click="myLocation">
-          <v-icon>mdi-crosshairs-gps</v-icon>
-        </v-btn>
 
         <v-btn
           fab absolute small
@@ -257,6 +258,7 @@
                 > {{currentComment.rating}}</b>
               </p>
               <v-btn
+                v-if="annotationsOpen"
                 fab x-small color="white"
                 :disabled="ratingpause"
                 class="primary--text"
@@ -921,24 +923,28 @@ export default {
 
     async rateUp(annotationPk) {
       this.ratingpause = true;
-      const csrftoken = this.$cookies.get('csrftoken', '');
-      const formData = new FormData();
 
-      const save = await this.$restApi.patch(`rateupannotation/${annotationPk}/`, formData, {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-          'X-CSRFToken': csrftoken
+      if (this.annotationsOpen) {
+        const csrftoken = this.$cookies.get('csrftoken', '');
+        const formData = new FormData();
+
+        const save = await this.$restApi.patch(`rateupannotation/${annotationPk}/`, formData, {
+          headers: {
+            'Content-Type': 'multipart/form-data',
+            'X-CSRFToken': csrftoken
+          }
+        });
+        if (save.status === 200) {
+          window.setTimeout(() => {
+            this.currentComment.rating = parseInt(save.data.rating, 10);
+          }, 1400);
+        } else {
+          console.log('Speichern fehlgeschlagen'); // eslint-disable-line no-console
         }
-      });
-      if (save.status === 200) {
-        window.setTimeout(() => {
-          this.currentComment.rating = parseInt(save.data.rating, 10);
-        }, 1400);
-      } else {
-        console.log('Speichern fehlgeschlagen'); // eslint-disable-line no-console
+
+        this.$refs.rateupBtn.$el.blur();
+        window.setTimeout(() => { this.ratingpause = false; }, 1800);
       }
-      this.$refs.rateupBtn.$el.blur();
-      window.setTimeout(() => { this.ratingpause = false; }, 1800);
     },
 
     myLocation() {


### PR DESCRIPTION
Closes #361
- Deactivates like button in map interface
- Adds data validation on REST API for `gsmap.workspace.annotation_open` flag