### PR TITLE
simple json keyvalue editor

### DIFF
--- a/django/docker/django/requirements/00/requirements.txt
+++ b/django/docker/django/requirements/00/requirements.txt
@@ -16,8 +16,8 @@ curtsies==0.3.4
 Django==3.1.14
 django-apscheduler==0.5.1
 django-cors-headers==3.7.0
+django-jsonform==2.9.0
 django-filter==2.4.0
-django-json-widget==1.1.1
 django-parler==2.3
 django-solo==1.1.5
 django-sortedm2m==3.0.2

--- a/django/gsmap/admin.py
+++ b/django/gsmap/admin.py
@@ -5,7 +5,6 @@ from django.contrib.auth import get_permission_codename
 from django.contrib.postgres import fields
 from django.utils.translation import gettext as _
 from django.utils.translation import ngettext as __
-from django_json_widget.widgets import JSONEditorWidget
 from django.utils.html import mark_safe
 from django.contrib import messages
 from django.forms.widgets import Textarea, TextInput
@@ -67,12 +66,6 @@ class SnapshotAdmin(admin.OSMGeoAdmin):
         #     ('perimeter',),
         # }),
     )
-
-    formfield_overrides = {
-        fields.JSONField: {
-            'widget': JSONEditorWidget
-        },
-    }
 
     list_display = ('id', 'thumbnail_list_image', 'title', 'municipality',
                     'permission', 'is_showcase', 'created', 'modified', 'user', 'data_file')

--- a/django/gsmap/models.py
+++ b/django/gsmap/models.py
@@ -29,7 +29,7 @@ from django.dispatch import receiver
 from django.urls import reverse
 from django.contrib.sites.models import Site
 
-
+from django_jsonform.models.fields import JSONField
 from parler.models import TranslatableModel, TranslatedFields
 
 from django.contrib.auth.models import Group
@@ -534,6 +534,32 @@ class Workspace(TranslatableModel):
         return f'{self.id}'
 
 class Annotation(models.Model):
+    DATA_SCHEMA = {
+        'type': 'object',
+        'properties': {
+            'type': { 
+                'type': 'string', 
+                'readonly': True, 
+                'default': 'Feature'
+            },
+            'geometry': { 
+                'type': 'object',
+                'additionalProperties': True,
+                'properties': {
+                }
+            },
+            'properties': {
+                'type': 'object',
+                'properties': {
+                    'fill': { 'type': 'boolean', 'readonly': True, 'default': True },
+                    'title': { 'type': 'string' },
+                    'description': { 'type': 'string' },
+                },
+                'additionalProperties': True
+            }
+        },
+    }
+
     class Meta:
         ordering = ['-created']
         permissions = [
@@ -554,7 +580,7 @@ class Annotation(models.Model):
         ('OBJ', _('Object')),
     ]
     kind = models.CharField(_("kind"), max_length=3, choices=KIND_CHOICES)
-    data = models.JSONField(_("data"), default=dict)
+    data = JSONField(_("data"), schema=DATA_SCHEMA, default=dict)
     category = models.ForeignKey(
         Category, default=None, blank=True,
         null=True, on_delete=models.SET_NULL

--- a/django/main/settings.py
+++ b/django/main/settings.py
@@ -65,7 +65,7 @@ INSTALLED_APPS = [
     'sorl.thumbnail',
     'sortedm2m',
     'sortedm2m_filter_horizontal_widget',
-    'django_json_widget',
+    'django_jsonform',
     'rest_framework',
     'django_apscheduler',
     'solo',


### PR DESCRIPTION
A simple json editor for annotation form data using [`django-jsonform`](https://github.com/bhch/django-jsonform). Allows editing properties and coordinates for `Point` markers. Polygon editing is currently not supported and requires additional features in django-jsonform - see https://github.com/bhch/django-jsonform/issues/39.